### PR TITLE
Update books.html

### DIFF
--- a/books.html
+++ b/books.html
@@ -81,9 +81,9 @@ Books that have not been released yet.
 </td></tr>
 
 <tr><td>
-	<a href="https://www.amazon.com/dp/1683927362?tag=realtimerenderin"><img src="AmazonImages/cgpioc3.jpg" alt="cover" height="50" align=left border=0></a>
+	<a href="https://www.amazon.com/dp/1501522590?tag=realtimerenderin"><img src="AmazonImages/cgpioc3.jpg" alt="cover" height="50" align=left border=0></a>
 	<img src="spacer.gif" alt="" height="50" width="12" align=left border=0>
-	<b><a href="https://www.amazon.com/dp/1683927362?tag=realtimerenderin">Computer Graphics Programming in OpenGL With C++ Third Edition</a></b>, by by V. Scott Gordon and John L. Clevenger, Mercury Learning & Information, February 2024.
+	<b><a href="https://www.amazon.com/dp/1501522590?tag=realtimerenderin">Computer Graphics Programming in OpenGL With C++ Third Edition</a></b>, by by V. Scott Gordon and John L. Clevenger, Mercury Learning & Information, February 2024.
 </td></tr>
 
 <tr><td>


### PR DESCRIPTION
updated c++ book link instead of java one.

i m not sure about the image link. I updated it as well, but could not find an image name `cgpioc3.jpg` that matches the one you had (I checked my browser network tab).